### PR TITLE
Thread Crashing on Windows OS before Execution

### DIFF
--- a/master_udp.py
+++ b/master_udp.py
@@ -143,6 +143,9 @@ def initiateMasterNode(port = 8080):
 	sync_thread = threading.Thread(target = synchronizeAllClocks) 
 	sync_thread.start() 
 
+	master_thread.join()
+	sync_thread.join()
+
 
 
 # Driver function 

--- a/slave_udp.py
+++ b/slave_udp.py
@@ -51,7 +51,7 @@ def initiateSlaveNode(master_port = 8080):
     slave_client = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)		 
 		
 	# define the master node address
-    server_address = ('127.0.0.1', server_port)
+    server_address = ('127.0.0.1', master_port)
 
     print("Slave node started...", end="\n\n")
 


### PR DESCRIPTION
- Errors solved for Windows OS resulting in threads to crash before executing in `master_udp.py` 
- Edit of `master_port` variable name which was different in `slave_udp.py`

*Update*
Both work seamlessly for different synchronization cycles